### PR TITLE
Update trust search route

### DIFF
--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -120,7 +120,7 @@ paths:
     get:
       tags:
       - "Academy"
-      summary: "Search for academies by matching fields in the body"
+      summary: "Search for academies by matching query parameters"
       description: ""
       operationId: "searchAcademies"
       consumes:
@@ -128,12 +128,14 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - in: "body"
-        name: "body"
-        description: "Search trusts using optional fields"
-        required: true
-        schema:
-          $ref: "#/definitions/SearchTrustsRequest"
+      - in: "query"
+        name: "urn"
+        description: "Search a using optional academy reference number"
+        type: "string"
+      - in: "query"
+        name: "name"
+        description: "Search a using optional academy name"
+        type: "string"
       responses:
         "405":
           description: "Invalid input"
@@ -346,13 +348,6 @@ securityDefinitions:
     in: header
     name: X-API-Key
 definitions:
-  SearchTrustsRequest:
-    type: "object"
-    properties:
-      urn:
-        type: "string"
-      name:
-        type: "string"
   CreateAcademyTransferProjectRequest:
     type: "object"
     properties:

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -68,8 +68,16 @@ paths:
       - "application/json"
       parameters:
       - in: "query"
-        name: "query"
-        description: "Optional string to find trusts with matching name, reference number or companies house number"
+        name: "group_name"
+        description: "Optional string to find trusts with matching name"
+        type: "string"
+      - in: "query"
+        name: "urn"
+        description: "Optional string to find trusts with matching reference number"
+        type: "string"
+      - in: "query"
+        name: "companies_house_number"
+        description: "Optional string to find trusts with matching companies house number"
         type: "string"
       responses:
         "405":
@@ -86,7 +94,7 @@ paths:
     get:
       tags:
       - "Academy"
-      summary: "Get academy by URN"
+      summary: "Get academy by Unique Reference Number (URN)"
       description: ""
       operationId: "getAcademy"
       consumes:

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -59,7 +59,7 @@ paths:
     get:
       tags:
       - "Trust"
-      summary: "Search for trusts by matching fields in the body"
+      summary: "Get trusts with optional query parameter"
       description: ""
       operationId: "searchTrusts"
       consumes:
@@ -67,12 +67,10 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - in: "body"
-        name: "body"
-        description: "Search trusts using optional fields"
-        required: true
-        schema:
-          $ref: "#/definitions/SearchTrustsRequest"
+      - in: "query"
+        name: "query"
+        description: "Optional string to find trusts with matching name, reference number or companies house number"
+        type: "string"
       responses:
         "405":
           description: "Invalid input"


### PR DESCRIPTION
This MR:
- Updates the `trusts` route to use route query parameters instead of the request body
- Update the `academies` route to use route query parameters instead of the request body