### PR TITLE
Add academy transfers project features

### DIFF
--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -828,10 +828,28 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/TransferringAcademy"
+      features:
+        $ref: "#/definitions/AcademyTransferProjectFeatures"
       state:
         type: "string"
       status:
         type: "string"
+  AcademyTransferProjectFeatures:
+    description: "Features of a transfer"
+    type: "object"
+    properties:
+      who_initiated_the_transfer:
+        type: "string"
+        description: "Whether DfE or the outgoing trust initiated the transfer"
+      rdd_or_esfa_intervention:
+        type: "boolean"
+        description: "Whether or not the transfer was started due to intervention by the RDD or ESFA"
+      rdd_or_esfa_intervention_detail:
+        type: "string"
+        description: "Further detail about RDD/ESFA Intervention"
+      type_of_transfer:
+        type: "string"
+        description: "The type of transfer this project is"
   TransferringAcademy:
     description: "Details of a transferring academy"
     type: object


### PR DESCRIPTION
## Context

The academy transfers team are currently working out what the new data we are capturing for our service is - as this is worked out we'll create new PRs to add various bits of data where required to the Academy Transfers project

## What data are we adding?

- Adding a new `features` object under the Academy Transfers project
- Adds new fields under the `features` object:
  - Who initiated the transfer
    - A radio button on the AT service for two values, for flexibility I made it a string here
  - RDD/ESFA Intervention + detail
    - A boolean as to whether or not there was intervention, and detail explaining it in the event there was
  - Type of transfer
    - A checkbox on the AT service - for flexibility this is also a string

These are all **new** fields, and not tied to any existing data captured within the service, and as such we don't need to be concerned about updating any existing data
