### PR TITLE
List academy transfer projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ The TRAMS (Trust and Academy Management System) system acts as a data source for
 
 The document is maintained here as a central contract so systems can develop against a consistent API while it is in development. It's generated and viewable using (Swagger)[swagger.io]
 
-Use `docker run -d -p 80:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/trams_api_spec.yaml swaggerapi/swagger-editor` to run the editor with the trams api spec pre loaded, on localhost:80
+Use `docker run -d -p 80:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/trams_api_spec/trams_api_spec.yaml swaggerapi/swagger-editor` to run the editor with the trams api spec pre loaded, on localhost:80

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -862,40 +862,36 @@ definitions:
         type: "string"
         description: "Unique reference for a project"
       outgoing_trust:
-        type: "object"
-        description: "The outgoing trust for the project"
-        properties: 
-          ukprn:
-            type: "string"
-            description: "The unique reference number for the outgoing trust"
-          name:
-            type: "string"
-            description: "The name of the outgoing trust"
+        $ref: "#/definitions/TrustSummary"
       transferring_academies: 
         type: "array"
         items:
           type: "object"
           properties: 
             outgoing_academy:
-              type: "object"
-              description: "An outgoing academy"
-              properties: 
-                ukprn: 
-                  type: "string"
-                  description: "Unique reference for outgoing academy"
-                name:
-                  type: "string"
-                  description: "The name of the outgoing academy"
+              $ref: "#/definitions/AcademySummary"
             incoming_trust:
-              type: "object"
-              description: "The incoming trust (optional)"
-              properties: 
-                ukprn:
-                  type: "string"
-                  description: "Unique reference for incoming trust"
-                name:
-                  type: "string"
-                  description: "The name of the incoming trust"
+              $ref: "#/definitions/TrustSummary"
+  TrustSummary:
+    description: "Summary of a trust"
+    type: "object"
+    properties: 
+      ukprn:
+        type: "string"
+        description: "The UKPRN for the trust"
+      group_name:
+        type: "string"
+        description: "The name of the trust"
+  AcademySummary: 
+    description: "Summary of an academy"
+    type: "object"
+    properties: 
+      ukprn:
+        type: "string"
+        description: "The UKPRN for the academy"
+      name:
+        type: "string"
+        description: "The name of the academy"
   AcademyTransferProjectFeatures:
     description: "Features of a transfer"
     type: "object"

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -214,8 +214,6 @@ paths:
       produces:
         - "application/json"
       responses:
-        "401":
-          description: "Bad request"
         "200":
           description: ""
           schema:

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -861,29 +861,41 @@ definitions:
       project_urn:
         type: "string"
         description: "Unique reference for a project"
-      outgoing_trust_urn:
-        type: "string"
-        description: "The unique reference number for the outgoing trust"
-      outgoing_trust_name:
-        type: "string"
-        description: "The name of the outgoing trust"
+      outgoing_trust:
+        type: "object"
+        description: "The outgoing trust for the project"
+        properties: 
+          ukprn:
+            type: "string"
+            description: "The unique reference number for the outgoing trust"
+          name:
+            type: "string"
+            description: "The name of the outgoing trust"
       transferring_academies: 
         type: "array"
         items:
           type: "object"
           properties: 
-            outgoing_academy_urn: 
-              type: "string"
-              description: "Unique reference for outgoing academy"
-            outgoing_academy_name:
-              type: "string"
-              description: "The name of the outgoing academy"
-            incoming_trust_urn:
-              type: "string"
-              description: "Unique reference for incoming trust (optional)"
-            incoming_trust_name:
-              type: "string"
-              description: "The name of the incoming trust"
+            outgoing_academy:
+              type: "object"
+              description: "An outgoing academy"
+              properties: 
+                ukprn: 
+                  type: "string"
+                  description: "Unique reference for outgoing academy"
+                name:
+                  type: "string"
+                  description: "The name of the outgoing academy"
+            incoming_trust:
+              type: "object"
+              description: "The incoming trust (optional)"
+              properties: 
+                ukprn:
+                  type: "string"
+                  description: "Unique reference for incoming trust"
+                name:
+                  type: "string"
+                  description: "The name of the incoming trust"
   AcademyTransferProjectFeatures:
     description: "Features of a transfer"
     type: "object"

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -858,9 +858,6 @@ definitions:
     description: "Listing academy transfer projects"
     type: "object"
     properties: 
-      urn:
-        type: "string"
-        description: "The unique reference number of the project"
       project_urn:
         type: "string"
         description: "Unique reference for a project"

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -877,6 +877,9 @@ definitions:
       ukprn:
         type: "string"
         description: "The UKPRN for the trust"
+      group_id:
+        type: "string"
+        description: "The group ID for the trust"
       group_name:
         type: "string"
         description: "The name of the trust"

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -204,6 +204,24 @@ paths:
             $ref: "#/definitions/AcademyTransferProject"
       security:
       - ApiKeyAuth: []
+  /academyTransferProjects:
+    get:
+      tags:
+        - "Academy Transfer Project"
+      summary: "List academy transfer projects"
+      description: "List truncated versions of academy transfer projects"
+      operationId: "listAcademyTransferProjects"
+      produces:
+        - "application/json"
+      responses:
+        "401":
+          description: "Bad request"
+        "200":
+          description: ""
+          schema:
+            $ref: "#/definitions/AcademyTransferProjectSearch"
+      security:
+      - ApiKeyAuth: []
   /academyTransferProject:
     post:
       tags:
@@ -359,6 +377,8 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/TransferringAcademy"
+      features:
+        $ref: "#/definitions/AcademyTransferProjectFeatures"
       state:
         type: "string"
       status:
@@ -834,6 +854,39 @@ definitions:
         type: "string"
       status:
         type: "string"
+  AcademyTransferProjectSearch:
+    description: "Listing academy transfer projects"
+    type: "object"
+    properties: 
+      urn:
+        type: "string"
+        description: "The unique reference number of the project"
+      project_urn:
+        type: "string"
+        description: "Unique reference for a project"
+      outgoing_trust_urn:
+        type: "string"
+        description: "The unique reference number for the outgoing trust"
+      outgoing_trust_name:
+        type: "string"
+        description: "The name of the outgoing trust"
+      transferring_academies: 
+        type: "array"
+        items:
+          type: "object"
+          properties: 
+            outgoing_academy_urn: 
+              type: "string"
+              description: "Unique reference for outgoing academy"
+            outgoing_academy_name:
+              type: "string"
+              description: "The name of the outgoing academy"
+            incoming_trust_urn:
+              type: "string"
+              description: "Unique reference for incoming trust (optional)"
+            incoming_trust_name:
+              type: "string"
+              description: "The name of the incoming trust"
   AcademyTransferProjectFeatures:
     description: "Features of a transfer"
     type: "object"

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -217,7 +217,7 @@ paths:
         "200":
           description: ""
           schema:
-            $ref: "#/definitions/AcademyTransferProjectListItem"
+            $ref: "#/definitions/AcademyTransferProjectSummary"
       security:
       - ApiKeyAuth: []
   /academyTransferProject:
@@ -852,7 +852,7 @@ definitions:
         type: "string"
       status:
         type: "string"
-  AcademyTransferProjectListItem:
+  AcademyTransferProjectSummary:
     description: "Listing academy transfer projects"
     type: "object"
     properties: 

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -219,7 +219,7 @@ paths:
         "200":
           description: ""
           schema:
-            $ref: "#/definitions/AcademyTransferProjectSearch"
+            $ref: "#/definitions/AcademyTransferProjectListItem"
       security:
       - ApiKeyAuth: []
   /academyTransferProject:
@@ -854,7 +854,7 @@ definitions:
         type: "string"
       status:
         type: "string"
-  AcademyTransferProjectSearch:
+  AcademyTransferProjectListItem:
     description: "Listing academy transfer projects"
     type: "object"
     properties: 


### PR DESCRIPTION
## Context

The Academy Transfers team will need the ability to list projects to be displayed on a dashboard. As discussed in slack - these objects will be truncated and not feature full objects that they relate to. 

For ease of displaying in the frontend - I have included:

- The name of the outgoing academy
- The name of the incoming trust (for the academy)
- The name of the outgoing trust

Any more data that is required in depth would need to be queried from the API separately