### PR TITLE
Update Academy (now Establishment) summary definition

### DIFF
--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -955,19 +955,19 @@ definitions:
       group_name:
         type: "string"
         description: "The name of the trust"
-  AcademySummary: 
-    description: "Summary of an academy"
+  EstablishmentSummary: 
+    description: "Summary of an establishment"
     type: "object"
     properties: 
       urn:
         type: "string"
-        description: "The URN for the academy"
+        description: "The URN for the establishment"
       ukprn:
         type: "string"
-        description: "The UKPRN for the academy"
+        description: "The UKPRN for the establishment"
       name:
         type: "string"
-        description: "The name of the academy"
+        description: "The name of the establishment"
   AcademyTransferProjectFeatures:
     description: "Features of a transfer"
     type: "object"
@@ -1056,7 +1056,7 @@ definitions:
     type: "object"
     properties: 
       outgoing_academy:
-        $ref: "#/definitions/AcademySummary"
+        $ref: "#/definitions/EstablishmentSummary"
       incoming_trust:
         $ref: "#/definitions/TrustSummary"
   ApplyToBecomeProject:

--- a/trams_api_spec/trams_api_spec.yaml
+++ b/trams_api_spec/trams_api_spec.yaml
@@ -959,6 +959,9 @@ definitions:
     description: "Summary of an academy"
     type: "object"
     properties: 
+      urn:
+        type: "string"
+        description: "The URN for the academy"
       ukprn:
         type: "string"
         description: "The UKPRN for the academy"


### PR DESCRIPTION
## Context

URNs are likely to be needed as much as establishment names, doing this prevents us from having to make multiple calls

## Changes

- Add URN to academy summary
- Update academy summary to establishment summary
